### PR TITLE
Added on-click callback-parameters

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -11,9 +11,9 @@ __all__ = ['ToastNotifier']
 import logging
 import threading
 from os import path
-from time import sleep
 from pkg_resources import Requirement
 from pkg_resources import resource_filename
+from time import sleep
 
 # 3rd party modules
 from win32api import GetModuleHandle
@@ -23,7 +23,6 @@ from win32con import IDI_APPLICATION
 from win32con import IMAGE_ICON
 from win32con import LR_DEFAULTSIZE
 from win32con import LR_LOADFROMFILE
-from win32con import WM_DESTROY
 from win32con import WM_USER
 from win32con import WS_OVERLAPPED
 from win32con import WS_SYSMENU
@@ -43,6 +42,11 @@ from win32gui import UnregisterClass
 from win32gui import Shell_NotifyIcon
 from win32gui import UpdateWindow
 from win32gui import WNDCLASS
+from win32gui import PumpMessages
+
+# Magic constants
+PARAM_DESTROY = 1028
+PARAM_CLICKED = 1029
 
 # ############################################################################
 # ########### Classes ##############
@@ -51,7 +55,6 @@ from win32gui import WNDCLASS
 
 class ToastNotifier(object):
     """Create a Windows 10  toast notification.
-
     from: https://github.com/jithurjacob/Windows-10-Toast-Notifications
     """
 
@@ -59,26 +62,45 @@ class ToastNotifier(object):
         """Initialize."""
         self._thread = None
 
-    def _show_toast(self, title, msg,
-                    icon_path, duration):
-        """Notification settings.
+    @staticmethod
+    def _decorator(func, callback=None, **kwargs):
+        """
+        :param func: callable to decorate
+        :param callback: callable to run on mouse click within notification window
+        :return: callable
+        """
+        main_kwargs = kwargs
 
+        def inner(*args, **kwargs):
+
+            kwargs.update({'callback': callback})
+            
+            for key, value in main_kwargs.items():
+                kwargs.update({key: value})
+
+            func(*args, **kwargs)
+        return inner
+
+    def _show_toast(self, title, msg,
+                    icon_path, duration,
+                    callback_on_click, **kwargs):
+        """Notification settings.
         :title: notification title
         :msg: notification message
         :icon_path: path to the .ico file to custom notification
         :duration: delay in seconds before notification self-destruction
         """
-        message_map = {WM_DESTROY: self.on_destroy, }
 
         # Register the window class.
         self.wc = WNDCLASS()
         self.hinst = self.wc.hInstance = GetModuleHandle(None)
         self.wc.lpszClassName = str("PythonTaskbar")  # must be a string
-        self.wc.lpfnWndProc = message_map  # could also specify a wndproc.
+        # Added kwargs to be used as Parameters for callback function
+        self.wc.lpfnWndProc = self._decorator(self.wnd_proc, callback_on_click, **kwargs)  # could instead specify simple mapping
         try:
             self.classAtom = RegisterClass(self.wc)
-        except:
-            pass #not sure of this
+        except (TypeError, Exception):
+            pass  # not sure of this
         style = WS_OVERLAPPED | WS_SYSMENU
         self.hwnd = CreateWindow(self.classAtom, "Taskbar", style,
                                  0, 0, CW_USEDEFAULT,
@@ -90,7 +112,7 @@ class ToastNotifier(object):
         if icon_path is not None:
             icon_path = path.realpath(icon_path)
         else:
-            icon_path =  resource_filename(Requirement.parse("win10toast"), "win10toast/data/python.ico")
+            icon_path = resource_filename(Requirement.parse("win10toast"), "win10toast/data/python.ico")
         icon_flags = LR_LOADFROMFILE | LR_DEFAULTSIZE
         try:
             hicon = LoadImage(self.hinst, icon_path,
@@ -108,6 +130,7 @@ class ToastNotifier(object):
                                       WM_USER + 20,
                                       hicon, "Balloon Tooltip", msg, 200,
                                       title))
+        PumpMessages()
         # take a rest then destroy
         sleep(duration)
         DestroyWindow(self.hwnd)
@@ -115,22 +138,23 @@ class ToastNotifier(object):
         return None
 
     def show_toast(self, title="Notification", msg="Here comes the message",
-                    icon_path=None, duration=5, threaded=False):
+                    icon_path=None, duration=5, threaded=False, callback_on_click=None, **kwargs):
         """Notification settings.
-
         :title: notification title
         :msg: notification message
         :icon_path: path to the .ico file to custom notification
         :duration: delay in seconds before notification self-destruction
         """
         if not threaded:
-            self._show_toast(title, msg, icon_path, duration)
+            self._show_toast(title, msg, icon_path, duration, callback_on_click, **kwargs)
         else:
             if self.notification_active():
                 # We have an active notification, let is finish so we don't spam them
                 return False
 
-            self._thread = threading.Thread(target=self._show_toast, args=(title, msg, icon_path, duration))
+            self._thread = threading.Thread(target=self._show_toast, args=(
+                title, msg, icon_path, duration, callback_on_click
+            ), **kwargs)
             self._thread.start()
         return True
 
@@ -141,17 +165,21 @@ class ToastNotifier(object):
             return True
         return False
 
-    def on_destroy(self, hwnd, msg, wparam, lparam):
-        """Clean after notification ended.
+    def wnd_proc(self, hwnd, msg, wparam, lparam, **kwargs):
+        """Messages handler method"""
 
-        :hwnd:
-        :msg:
-        :wparam:
-        :lparam:
-        """
+        if lparam == PARAM_CLICKED:
+            # callback goes here
+            if kwargs.get('callback'):
+                kwargs.pop('callback')(**kwargs)
+            self.on_destroy(hwnd, msg, wparam, lparam)
+        elif lparam == PARAM_DESTROY:
+            self.on_destroy(hwnd, msg, wparam, lparam)
+
+    def on_destroy(self, hwnd, msg, wparam, lparam):
+        """Clean after notification ended."""
         nid = (self.hwnd, 0)
         Shell_NotifyIcon(NIM_DELETE, nid)
         PostQuitMessage(0)
 
         return None
-


### PR DESCRIPTION
Enhancement of Added on-click callback feature #38. 
New code now supports parameters to be passed to callback function.

Issue: When including parameters to callback function, the function gets executed before the notification. The intention of the on-click was to wait for user click the notification before execute the function

def say_hello():
    print('Hello!')
toast = ToastNotifier()
toast.show_toast( title="Notification", msg="Here comes the message",
                    icon_path=None, duration=5, threaded=False, callback_on_click=say_hello(param))

With new code:

def say_hello(**kwargs):
    print(kwargs.get('func_param1 ') + kwargs.get('func_param2 '))

toast = ToastNotifier()
toast.show_toast( title="Notification", 
                            msg="Here comes the message",
                            icon_path=None,
                            duration=5, 
                           threaded=False, 
                           callback_on_click=say_hello,
                           func_param1 = 'Hello',
                           func_param2 = 'World'
)